### PR TITLE
feat: 메뉴 수정 화면 구현

### DIFF
--- a/owner/lib/Screen/menu_manage_edit.dart
+++ b/owner/lib/Screen/menu_manage_edit.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+
+// 현재 틀만 만들어진 상태 기능 구현 필요
+// 메뉴 선택해서 수정 페이지로 넘어올 때 각 입력창에는 직전에 선택해서 넘어온
+//메뉴의 정보가 회색으로 써있고 수정하고 싶은 정보만 선택적으로 수정할 수 있도록 해야함
+
+class EditMenu extends StatefulWidget {
+  const EditMenu({super.key});
+
+  @override
+  State<EditMenu> createState() => _EditMenuState();
+}
+
+class _EditMenuState extends State<EditMenu> {
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        FocusScope.of(context).unfocus();
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          shadowColor: Colors.black,
+          elevation: 1,
+          title: const Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Text(
+                '메뉴 수정  ',
+                style: TextStyle(fontSize: 24, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 20),
+                  child: Text(
+                    '수정할 메뉴의 정보를 입력해주세요',
+                    style: TextStyle(fontSize: 17, fontWeight: FontWeight.w500),
+                  ),
+                ),
+                Container(
+                  clipBehavior: Clip.hardEdge,
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 4, horizontal: 23),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(20),
+                    color: const Color.fromARGB(255, 222, 234, 187),
+                  ),
+                  child: const Text(
+                    '메뉴 이름',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                  ),
+                ),
+                const SizedBox(
+                  height: 1,
+                ),
+                Container(
+                  height: 36,
+                  width: 400,
+                  decoration: BoxDecoration(
+                    boxShadow: [
+                      BoxShadow(
+                        blurRadius: 2,
+                        color: Colors.black.withOpacity(0.3),
+                        offset: const Offset(1, 3),
+                      )
+                    ],
+                    borderRadius: BorderRadius.circular(70),
+                  ),
+                  child: TextField(
+                    decoration: InputDecoration(
+                      filled: true,
+                      fillColor: Colors.white,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(70.0),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    autofocus: true,
+                  ),
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+                Row(
+                  children: [
+                    Container(
+                      clipBehavior: Clip.hardEdge,
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 4, horizontal: 23),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(20),
+                        color: const Color.fromARGB(255, 222, 234, 187),
+                      ),
+                      child: const Text(
+                        '원가',
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.w500),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 1,
+                ),
+                Container(
+                  height: 36,
+                  width: 400,
+                  decoration: BoxDecoration(
+                    boxShadow: [
+                      BoxShadow(
+                        blurRadius: 2,
+                        color: Colors.black.withOpacity(0.3),
+                        offset: const Offset(1, 3),
+                      )
+                    ],
+                    borderRadius: BorderRadius.circular(70),
+                  ),
+                  child: TextField(
+                    decoration: InputDecoration(
+                      filled: true,
+                      fillColor: Colors.white,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(70.0),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    autofocus: true,
+                  ),
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+                Container(
+                  clipBehavior: Clip.hardEdge,
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 4, horizontal: 23),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(20),
+                    color: const Color.fromARGB(255, 222, 234, 187),
+                  ),
+                  child: const Text(
+                    '할인가',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                  ),
+                ),
+                const SizedBox(
+                  height: 1,
+                ),
+                Container(
+                  height: 36,
+                  width: 400,
+                  decoration: BoxDecoration(
+                    boxShadow: [
+                      BoxShadow(
+                        blurRadius: 2,
+                        color: Colors.black.withOpacity(0.3),
+                        offset: const Offset(1, 3),
+                      )
+                    ],
+                    borderRadius: BorderRadius.circular(70),
+                  ),
+                  child: TextField(
+                    decoration: InputDecoration(
+                      filled: true,
+                      fillColor: Colors.white,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(70.0),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    autofocus: true,
+                  ),
+                ),
+                const SizedBox(
+                  height: 30,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      alignment: Alignment.center,
+                      width: 130,
+                      height: 70,
+                      decoration: BoxDecoration(
+                          boxShadow: [
+                            BoxShadow(
+                              blurRadius: 2,
+                              color: Colors.black.withOpacity(0.3),
+                              offset: const Offset(0, 3),
+                            )
+                          ],
+                          color: const Color.fromARGB(255, 210, 210, 210),
+                          borderRadius: BorderRadius.circular(15)),
+                      child: const Text(
+                        '사진 수정하기',
+                        style: TextStyle(
+                            fontSize: 17, fontWeight: FontWeight.w500),
+                      ),
+                    ),
+                    Container(
+                        width: 150,
+                        height: 150,
+                        decoration: const BoxDecoration(
+                          color: Color.fromARGB(255, 240, 240, 240),
+                        ))
+                  ],
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 120),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      OutlinedButton(
+                        onPressed: () {},
+                        style: OutlinedButton.styleFrom(
+                          shadowColor: Colors.black,
+                          elevation: 2,
+                          backgroundColor:
+                              const Color.fromARGB(255, 222, 234, 187),
+                          minimumSize: const Size(120, 60),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                          side: const BorderSide(
+                              color: Color.fromARGB(255, 222, 234, 187)),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 8,
+                          ),
+                        ),
+                        child: const Text(
+                          '수정하기',
+                          style: TextStyle(
+                            color: Colors.black,
+                            fontSize: 20,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/owner/lib/main.dart
+++ b/owner/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:leftover_is_over_owner/Screen/menu_manage_edit.dart';
 import 'package:leftover_is_over_owner/Screen/select_store_page.dart';
 import 'package:leftover_is_over_owner/Screen/login_page.dart';
 import 'package:leftover_is_over_owner/Screen/main_page.dart';
@@ -21,7 +22,8 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: const AddMenu(),
+      home: const EditMenu(),
+      //AddMenu(),
       //RegisterPage(),
       //SelectStore(),
       //SalesManagePage()


### PR DESCRIPTION
현재 틀만 만들어진 상태로 수정 기능 구현 필요

메뉴 선택해서 수정 페이지로 넘어올 때 각 입력 창에는 직전에 선택해서 넘어온
메뉴의 정보가 회색으로 써있고 수정하고 싶은 정보만 선택적으로 수정할 수 있도록 해야 함